### PR TITLE
refs #354. Making the highlights checkboxes rather than autocomplete.

### DIFF
--- a/cc-taxonomies/cc-taxonomies.php
+++ b/cc-taxonomies/cc-taxonomies.php
@@ -54,7 +54,7 @@ function cc_taxonomy_highlight() {
   );
   $args = array(
     'labels'                     => $labels,
-    'hierarchical'               => false,
+    'hierarchical'               => true,
     'public'                     => true,
     'show_ui'                    => true,
     'show_admin_column'          => true,


### PR DESCRIPTION
This fix pertains to the thread on 

https://github.com/creativecommons/creativecommons.org/issues/354

Hero/Featured is currently an autocomplete. This makes them checkboxes.