### PR TITLE
Add user slug id to each member in team shortcode

### DIFF
--- a/cc-author/shortcodes/cc-author-shortcode-team.php
+++ b/cc-author/shortcodes/cc-author-shortcode-team.php
@@ -60,8 +60,8 @@ function cc_team_listing_shortcode( $atts ) {
         ksort($users);
 
         foreach ($users as $user){
-
-          $output .= '<li class="team-member">';
+          $user_slug = sanitize_title_with_dashes( $user->first_name . $user->last_name );
+          $output .= '<li class="team-member" id="'.$user_slug.'">';
           $output .= '  <a class="user-profile" href="' . get_author_posts_url($user->ID) . '">';
           $output .= '  <div class="image">';
           $output .=      get_avatar($user->ID, '300');


### PR DESCRIPTION
Fixes creativecommons/creativecommons.org#914

**Description**
This fix will add a user slug to each member item displayed in [team page](https://creativecommons.org/about/team) this will work with internal links

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
